### PR TITLE
Lookup Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,14 @@ hello-user = Hello {$name}!
 ``` ruby
 require "nii"
 
-# Create a localization context for American English,
-# with locale data from locales directory, set "hello" as the default namespace
-context = Nii::Context.new "en-US", Nii["locales"], namespace: "hello"
+# Create a Nii configuration
+config = Nii.setup do
+  lookup "./locales"
+  default_namespace "hello"
+end
+
+# Create a localization context (usually per request)
+context = Nii::Context.new "en-US", config
 
 # render "hello-world" from locales/en/hello.ftl
 context.render "hello-world" # => "Hello World!"
@@ -59,8 +64,6 @@ You may also want to install one or more of the following optional dependencies:
 * **tomlrb** – Recommended if you want to use [TOML files](https://toml.io/en/) for localizations. A use case would be to share localizations with [go-i18n](https://github.com/nicksnyder/go-i18n).
 
 ## Etymology
-
-<!-- keep in sync with web/source/glossary/nii.html.md --->
 
 The word "Nii" is:
 * The name of a language spoken by between 10,000 and 25,000 people in the highlands of Papua New Guinea.

--- a/nii-core/lib/nii/locale_preference.rb
+++ b/nii-core/lib/nii/locale_preference.rb
@@ -51,12 +51,13 @@ module Nii
     end
 
     def &(other)
+      return self if other.nil?
       locales = self.locales.map { |l| l & other if l.combinable? other }.compact
       LocalePreference.new(locales)
     end
 
     def |(other)
-      return self if locales.include? other
+      return self if other.nil? or locales.include? other
       LocalePreference.new(other, locales.reject { |l| l.subset_of? other })
     end
 

--- a/nii-core/lib/nii/lookup.rb
+++ b/nii-core/lib/nii/lookup.rb
@@ -5,6 +5,7 @@ module Nii
     # @api internal
     LOADERS = {}
 
+    autoload :Cascade,    'nii/lookup/cascade'
     autoload :Common,     'nii/lookup/common'
     autoload :Default,    'nii/lookup/default'
     autoload :FileCache,  'nii/lookup/file_cache'
@@ -14,7 +15,7 @@ module Nii
 
     def self.[](key)
       require "nii/lookup/#{key}" unless LOADERS.include? key
-      LOADERS.fetch(key)
+      LOADERS.fetch(key.to_sym)
     end
 
     def self.[]=(key, value)

--- a/nii-core/lib/nii/lookup/cascade.rb
+++ b/nii-core/lib/nii/lookup/cascade.rb
@@ -2,6 +2,11 @@
 
 module Nii::Lookup
   class Cascade < Common
+    Nii::Lookup[:cascade] = self
+
+    # @private
+    def self.setup_class = Nii::Setup::Lookup::Cascade
+
     attr_reader :backends
 
     private

--- a/nii-core/lib/nii/lookup/common.rb
+++ b/nii-core/lib/nii/lookup/common.rb
@@ -7,6 +7,9 @@ module Nii::Lookup
   #
   # @see Nii::Lookup::Default
   class Common
+    # @private
+    def self.setup_class = Nii::Setup::Lookup::Common
+
     # @return [Nii::Config]
     attr_reader :config
 
@@ -33,7 +36,7 @@ module Nii::Lookup
     # @return [Nii::LocalePreference]
     def available_locales(cache = !config.reload_templates?)
       return @lock.with_read_lock { @available_locales ||= available_locales(false) } if cache
-      Nii::LocalePreference.new(config.locale || scan_locales.compact.map(&:to_s))
+      Nii::LocalePreference.new(config.locale || scan_locales.compact.map(&:to_s)) & config.available_locales
     end
 
     def matches?(locale, namespace, message)
@@ -71,6 +74,10 @@ module Nii::Lookup
     def to_nii_lookup
       self
     end
+
+    # @raise [NotImplementedError]
+    # @return self
+    def <<(source) = raise(NotImplementedError, "#{self.class} does not support adding sources")
 
     private
 

--- a/nii-core/lib/nii/lookup/file_system.rb
+++ b/nii-core/lib/nii/lookup/file_system.rb
@@ -23,11 +23,22 @@ module Nii::Lookup
   #   context = Nii::Context.new('en') { |c| c.lookup = MyLookup.new(path: './locales') }
   #   puts context.render(:hello, namespace: :world)
   class FileSystem < Common
+    # @private
+    def self.setup_class = Nii::Setup::Lookup::FileSystem
+
     attr_reader :load_path, :formats
 
     # @private
     def inspect
       "#<#{self.class}:#{load_path.to_a.inspect}>"
+    end
+
+    # Adds a path to the message lookup.
+    # @param (see Nii::LoadPath#<<)
+    # @return self
+    def <<(source)
+      load_path << source
+      self
     end
 
     private

--- a/nii-core/lib/nii/lookup/memory.rb
+++ b/nii-core/lib/nii/lookup/memory.rb
@@ -16,6 +16,9 @@ module Nii::Lookup
   class Memory < Common
     Nii::Lookup[:memory] = self
 
+    # @private
+    def self.setup_class = Nii::Setup::Lookup::Memory
+
     # DSL object used by the block passed to {Memory#initialize}.
     class DSL
       # @api internal

--- a/nii-core/lib/nii/setup.rb
+++ b/nii-core/lib/nii/setup.rb
@@ -6,15 +6,16 @@ module Nii
     autoload :Finalized,  'nii/setup/finalized'
     autoload :Helpers,    'nii/setup/helpers'
     autoload :Locale,     'nii/setup/locale'
+    autoload :Lookup,     'nii/setup/lookup'
     autoload :Middleware, 'nii/setup/middleware'
     autoload :RouteScope, 'nii/setup/route_scope'
     autoload :Shared,     'nii/setup/shared'
     autoload :Vanilla,    'nii/setup/vanilla'
 
-    def self.new(application = nil, &block)
+    def self.new(application = nil, **options, &block)
       klass = constants.map { |c| const_get(c, false) }.detect { |c| c.respond_to?(:for?) and c.for? application }
       raise ArgumentError, "don't know how to run setup for #{application.inspect}" unless klass
-      klass.setup(application, &block)
+      klass.setup(application, **options, &block)
     end
   end
 end

--- a/nii-core/lib/nii/setup/lookup.rb
+++ b/nii-core/lib/nii/setup/lookup.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Nii::Setup
+  module Lookup
+    autoload :Cascade,    'nii/setup/lookup/cascade'
+    autoload :Common,     'nii/setup/lookup/common'
+    autoload :FileSystem, 'nii/setup/lookup/file_system'
+    autoload :Memory,     'nii/setup/lookup/memory'
+
+    def self.prepare(type  = nil, *paths, **options)
+      type, paths = nil, [type, *paths] if type.is_a? String
+      type      ||= URI.parse(paths.first).scheme rescue nil
+      type      ||= :default
+      type        = Nii::Lookup[type] unless type.resond_to? :setup_class
+      type.setup_class.new(type, *paths, **options)
+    end
+  end
+end

--- a/nii-core/lib/nii/setup/lookup/cascade.rb
+++ b/nii-core/lib/nii/setup/lookup/cascade.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Nii::Setup::Lookup
+  class Cascade < Common
+    # @api internal
+    def initialize(type = Nii::Lookup::Cascade, *sources, **options) = super
+
+    # @api internal
+    def any? = @sources.any?
+    
+    # @api internal
+    def _build(config)
+      backends = @sources.map { _1._build(config) }
+      backends.size > 1 ? super(config.merge(backends: backends)) : backends.first
+    end
+
+    private
+
+    def add_sources(lookup) = nil
+  end
+end

--- a/nii-core/lib/nii/setup/lookup/common.rb
+++ b/nii-core/lib/nii/setup/lookup/common.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Nii::Setup::Lookup
+  class Common
+    include Nii::Setup::Shared::Config, Nii::Setup::Shared::Locales
+
+    # @api internal
+    def initialize(type, *sources, **options)
+      @type     = type
+      @sources  = sources
+      @callback = nil
+      yield self if block_given?
+    end
+
+    # @api internal
+    def <<(value) = @sources << value
+
+    # @api internal
+    def _build(config)
+      config = Nii::Config.new(config.except(:lookup).merge(@config))
+      lookup = @type.new(config, &@callback)
+      add_sources(lookup)
+      lookup
+    end
+
+    # @api setup
+    #
+    # Enables automatic message template reloading whenever localization files change.
+    # Framework integrations like nii-rails and nii-sinatra will typically set this
+    # option for you in development mode.
+    #
+    # @default false
+    def reload_templates(value = true) = set(:reload_templates, value)
+
+    private
+
+    def add_sources(lookup) = @sources.each { lookup << _1 }
+  end
+end

--- a/nii-core/lib/nii/setup/lookup/file_system.rb
+++ b/nii-core/lib/nii/setup/lookup/file_system.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Nii::Setup::Lookup
+  class FileSystem < Common
+    # @api setup
+    def paths(*paths) = @sources.concat(paths)
+    alias_method :path, :paths
+
+    # @api setup
+    def files(*paths) = add(:files, paths)
+    alias_method :file, :files
+  end
+end

--- a/nii-core/lib/nii/setup/lookup/memory.rb
+++ b/nii-core/lib/nii/setup/lookup/memory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Nii::Setup::Lookup
+  class Memory < Common
+    # @api internal
+    def __dsl__(&block) = @callback = block
+  end
+end


### PR DESCRIPTION
The main part of the Setup API that's still missing is the ability to configure message lookup.

This PR (still WIP) adds support:

``` ruby
Nii::Setup.new do
  lookup "app/locales" # use default lookup for app/locales

  # if a URL is passed, it will attempt to load nii/lookup/{schema}
  lookup "https://api.example.com/locales" do
    locales :fr, :it # locales can be limited by lookup source
    # http specific options can go here
  end

  lookup "postgres://localhost/nii-development" do
    table "translations"
  end

  lookup :i18n do # i18n directory structure (locale is part of file name)
    namespace "i18n"
    path "config/locale"
    files I18n.load_path # copy list of files from I18n
    reload_templates # template reloading can be enabled/disabled per lookup
  end

  lookup :memory do
    namespace :example
    locale(:en) { add example: "example message"   }
    locale(:de) { add example: "Beispielnachricht" }
  end
end
```

Note that neither HTTP nor SQL based lookup are implemented at the moment.